### PR TITLE
Fixed OW Cam displacement from screenshake

### DIFF
--- a/Assets/Scripts/Device/GlobalControls.cs
+++ b/Assets/Scripts/Device/GlobalControls.cs
@@ -59,6 +59,7 @@ public class GlobalControls : MonoBehaviour {
     /// Control checking, and way more.
     /// </summary>
 	void Update () {
+		stopScreenShake = false;
         frame ++;
         if (SceneManager.GetActiveScene().name == "EncounterSelect") lastSceneUnitale = true;
         else                                                         lastSceneUnitale = false;
@@ -114,7 +115,6 @@ public class GlobalControls : MonoBehaviour {
         if (Screen.currentResolution.height != 480 || Screen.currentResolution.width != 640) {
             Screen.SetResolution(640, 480, false, 0);
         }
-        stopScreenShake = false;
     }
     
     void LoadScene(Scene scene, LoadSceneMode mode) {


### PR DESCRIPTION
The Overworld Camera was being displaced if a battle was exited during a screen shake, This was proven fixed by moving one line.

Without this fix, go into the OW, press B, then activate a screen shake with either X or P and press escape before the camera moves back. When you return to the Overworld, the main camera will be displaced based on the displacement from the screen shake from the battle. That's fixed in this commit, I tested it.