### PR TITLE
update the player hitbox based on the sprite

### DIFF
--- a/Assets/Scripts/PlayerControllers/PlayerController.cs
+++ b/Assets/Scripts/PlayerControllers/PlayerController.cs
@@ -436,6 +436,8 @@ public class PlayerController : MonoBehaviour {
             if (invulTimer <= 0.0f)
                 selfImg.enabled = true;
         }
+        // constantly update the hitbox to match the sprite
+        playerAbs = new Rect(0, 0, selfImg.sprite.texture.width - hitboxInset * 2, selfImg.sprite.texture.height - hitboxInset * 2);
         
         // constantly update the hitbox to match the position of the sprite itself
         playerAbs.x = (luaStatus.sprite.absx - (luaStatus.sprite.width  * self.pivot.x)) + hitboxInset;


### PR DESCRIPTION
Previously if you tried to change the sprite of the player then the hitbox will not update.
So I changed it so it will update based on the sprite every frame (I tested it, and it doesn't impact performance).