### PR TITLE
Add enemy management

### DIFF
--- a/Assets/Scripts/Battle/EnemyController.cs
+++ b/Assets/Scripts/Battle/EnemyController.cs
@@ -330,7 +330,6 @@ public class EnemyController : MonoBehaviour {
 
     public void Remove() {
         try {
-            SetActive(false);
             UIController.instance.encounter.enemies.Remove(this);
             Destroy(gameObject);
         } catch (MissingReferenceException) {

--- a/Assets/Scripts/Battle/EnemyController.cs
+++ b/Assets/Scripts/Battle/EnemyController.cs
@@ -248,7 +248,7 @@ public class EnemyController : MonoBehaviour {
         get { return GetComponent<RectTransform>().position.y; }
     }
 
-    private void Start() {
+    public void InitializeEnemy() {
         try {
             string scriptText = ScriptRegistry.Get(ScriptRegistry.MONSTER_PREFIX + scriptName);
             if (scriptText == null) {

--- a/Assets/Scripts/Battle/EnemyController.cs
+++ b/Assets/Scripts/Battle/EnemyController.cs
@@ -269,6 +269,7 @@ public class EnemyController : MonoBehaviour {
             script.Bind("SetDamageUIOffset", (Action<int, int>)SetDamageUIOffset);
             script.Bind("SetSliceAnimOffset", (Action<int, int>)SetSliceAnimOffset);
             script.Bind("State", (Action<Script, string>)UIController.SwitchStateOnString);
+            script.Bind("Remove", (Action)Remove);
             script.SetVar("canmove", DynValue.NewBoolean(false));
             sprite = new LuaSpriteController(GetComponent<Image>());
             script.SetVar("monstersprite", UserData.Create(sprite, LuaSpriteController.data));
@@ -325,6 +326,16 @@ public class EnemyController : MonoBehaviour {
 
     protected void HandleCustomCommand(string command) {
         TryCall("HandleCustomCommand", new[] { DynValue.NewString(command) });
+    }
+
+    public void Remove() {
+        try {
+            SetActive(false);
+            UIController.instance.encounter.enemies.Remove(this);
+            Destroy(gameObject);
+        } catch (MissingReferenceException) {
+            throw new CYFException("Attempt to remove a removed enemy.");
+        }
     }
 
     public void SetSprite(string filename) {

--- a/Assets/Scripts/Battle/EnemyEncounter.cs
+++ b/Assets/Scripts/Battle/EnemyEncounter.cs
@@ -7,11 +7,11 @@ using UnityEngine.UI;
 using Random = UnityEngine.Random;
 
 public class EnemyEncounter : MonoBehaviour {
-    public EnemyController[] enemies;
+    public List<EnemyController> enemies;
     public Vector2[] enemyPositions;
     internal float waveTimer;
     public int turnCount;
-    protected GameObject[] enemyInstances;
+    protected List<GameObject> enemyInstances = new List<GameObject>();
 
     public string EncounterText { get; set; }
     public bool CanRun { get; set; }
@@ -50,8 +50,26 @@ public class EnemyEncounter : MonoBehaviour {
             script.Bind("CreateProjectile", (Func<Script, string, float, float, string, DynValue>)CreateProjectile);
             script.Bind("CreateProjectileAbs", (Func<Script, string, float, float, string, DynValue>)CreateProjectileAbs);
             script.Bind("SetButtonLayer", (Action<string>)LuaScriptBinder.SetButtonLayer);
+            script.Bind("CreateEnemy", (Func<string, float, float, DynValue>)CreateEnemy);
             return true;
         }
+    }
+
+    public DynValue CreateEnemy(string enemyScript, float x, float y) {
+        GameObject enemyObject = Instantiate(Resources.Load<GameObject>("Prefabs/LUAEnemy 1"));
+
+        enemyObject.transform.SetParent(gameObject.transform);
+        enemyObject.transform.localScale = new Vector3(1, 1, 1); // apparently this was suddenly required or the scale would be (0,0,0)
+        enemyInstances.Add(enemyObject);
+
+        EnemyController enemyController = enemyObject.GetComponent<EnemyController>();
+        enemyController.scriptName = enemyScript;
+        enemyController.index = enemies.Count - 1;
+        enemyController.GetComponent<RectTransform>().anchoredPosition = new Vector2(x, y);
+        enemyController.script = new ScriptWrapper();
+        enemies.Add(enemyController);
+        enemyController.InitializeEnemy();
+        return UserData.Create(enemyController.script);
     }
 
     public bool CallOnSelfOrChildren(string func, DynValue[] param = null) {
@@ -104,20 +122,18 @@ public class EnemyEncounter : MonoBehaviour {
         DynValue enemyPositionsLua = script.GetVar("enemypositions");
         string musicFile = script.GetVar("music").String;
 
-        try { enemies = new EnemyController[enemyScriptsLua.Table.Length]; /*dangerously assumes enemies is defined*/ }
-        catch (Exception) {
-            UnitaleUtil.DisplayLuaError(StaticInits.ENCOUNTER, "There's no enemies table in your encounter. Is this a pre-0.1.2 encounter? It's easy to fix!\n\n"
-                + "1. Create a Monsters folder in the mod's Lua folder\n"
-                + "2. Add the monster script (custom.lua) to this new folder\n"
-                + "3. Add the following line to the beginning of this encounter script, located in the mod folder/Lua/Encounters:\nenemies = {\"custom\"}\n"
-                + "4. You're done! Starting from 0.1.2, you can name your monster and encounter scripts anything.");
+        if (enemyScriptsLua.Table == null) {
+            UnitaleUtil.DisplayLuaError(StaticInits.ENCOUNTER, "There has to be an enemies table in your encounter's file.");
             return;
         }
+
+        int enemyCount = enemyScriptsLua.Table.Length;
+
         if (enemyPositionsLua != null && enemyPositionsLua.Table != null) {
             enemyPositions = new Vector2[enemyPositionsLua.Table.Length];
             for (int i = 0; i < enemyPositionsLua.Table.Length; i++) {
                 Table posTable = enemyPositionsLua.Table.Get(i + 1).Table;
-                if (i >= enemies.Length)
+                if (i >= enemyCount)
                     break;
 
                 enemyPositions[i] = new Vector2((float)posTable.Get(1).Number, (float)posTable.Get(2).Number);
@@ -139,28 +155,18 @@ public class EnemyEncounter : MonoBehaviour {
             NewMusicManager.audioname["src"] = MusicManager.filename;
         }
         // Instantiate all the enemy objects
-        if (enemies.Length > enemyPositions.Length) {
+        if (enemyCount > enemyPositions.Length) {
             UnitaleUtil.DisplayLuaError(StaticInits.ENCOUNTER, "All enemies in an encounter must have a screen position defined. Either your enemypositions table is missing, "
                 + "or there are more enemies than available positions. Refer to the documentation's Basic Setup section on how to do this.");
         }
-        enemyInstances = new GameObject[enemies.Length];
-        for (int i = 0; i < enemies.Length; i++) {
-            enemyInstances[i] = Instantiate(Resources.Load<GameObject>("Prefabs/LUAEnemy 1"));
-            enemyInstances[i].transform.SetParent(gameObject.transform);
-            enemyInstances[i].transform.localScale = new Vector3(1, 1, 1); // apparently this was suddenly required or the scale would be (0,0,0)
-            enemies[i] = enemyInstances[i].GetComponent<EnemyController>();
-            enemies[i].scriptName = enemyScriptsLua.Table.Get(i + 1).String;
-            enemies[i].index = i;
-            enemies[i].GetComponent<RectTransform>().anchoredPosition = i < enemyPositions.Length ? new Vector2(enemyPositions[i].x, enemyPositions[i].y) : new Vector2(0, 1);
+
+        enemies = new List<EnemyController>();
+        Table luaEnemyTable = script.GetVar("enemies").Table;
+
+        for (int i = 0; i < enemyCount; i++) {
+            luaEnemyTable.Set(i + 1, CreateEnemy(enemyScriptsLua.Table.Get(i + 1).String, enemyPositions[i].x, enemyPositions[i].y));
         }
 
-        // Attach the controllers to the encounter's enemies table
-        DynValue[] enemyStatusCtrl = new DynValue[enemies.Length];
-        Table luaEnemyTable = script.GetVar("enemies").Table;
-        for (int i = 0; i < enemyStatusCtrl.Length; i++) {
-            enemies[i].script = new ScriptWrapper();
-            luaEnemyTable.Set(i + 1, UserData.Create(enemies[i].script));
-        }
         script.SetVar("enemies", DynValue.NewTable(luaEnemyTable));
         Table luaWaveTable = new Table(null);
         script.SetVar("Wave", DynValue.NewTable(luaWaveTable));

--- a/Assets/Scripts/Battle/EnemyEncounter.cs
+++ b/Assets/Scripts/Battle/EnemyEncounter.cs
@@ -11,7 +11,6 @@ public class EnemyEncounter : MonoBehaviour {
     public Vector2[] enemyPositions;
     internal float waveTimer;
     public int turnCount;
-    protected List<GameObject> enemyInstances = new List<GameObject>();
 
     public string EncounterText { get; set; }
     public bool CanRun { get; set; }
@@ -60,7 +59,6 @@ public class EnemyEncounter : MonoBehaviour {
 
         enemyObject.transform.SetParent(gameObject.transform);
         enemyObject.transform.localScale = new Vector3(1, 1, 1); // apparently this was suddenly required or the scale would be (0,0,0)
-        enemyInstances.Add(enemyObject);
 
         EnemyController enemyController = enemyObject.GetComponent<EnemyController>();
         enemyController.scriptName = enemyScript;

--- a/Assets/Scripts/Battle/UIController.cs
+++ b/Assets/Scripts/Battle/UIController.cs
@@ -952,8 +952,8 @@ public class UIController : MonoBehaviour {
                 case UIState.MERCYMENU:
                     switch (selectedMercy) {
                         case 0: {
-                            bool[] canSpare = new bool[encounter.enemies.Length];
-                            int    count    = encounter.enemies.Length;
+                            bool[] canSpare = new bool[encounter.enemies.Count];
+                            int    count    = encounter.enemies.Count;
                             for (int i = 0; i < count; i++)
                                 canSpare[i] = encounter.enemies[i].CanSpare;
                             EnemyController[] enabledEnTemp = encounter.EnabledEnemies;
@@ -1331,7 +1331,7 @@ public class UIController : MonoBehaviour {
         ControlPanel.instance.FrameBasedMovement = false;
 
         LuaScriptBinder.CopyToBattleVar();
-        spareList = new bool[encounter.enemies.Length];
+        spareList = new bool[encounter.enemies.Count];
         for (int i = 0; i < spareList.Length; i ++)
             spareList[i] = false;
         if (EnemyEncounter.script.GetVar("Update") != null)


### PR DESCRIPTION
This PR adds the encounter function `CreateEnemy(script,x,y)`, which lets you create an enemy while the encounter is running. This function returns the ScriptWrapper object, which is not added to the default enemies table.

It also adds the `Remove()` function from enemy scripts which removes the enemy from the battle. Note that this does not actually remove the script reference; it solely removes the GameObject (and removes it from the internal enemies list.) It will throw an error if you try to destroy an enemy which is already destroyed.

Finally, this PR shortens an outdated error when the `enemies` table does not exist, to be more clear and concise.