### PR TITLE
Add ability to access enemy scripts by name

### DIFF
--- a/Assets/Scripts/Battle/EnemyEncounter.cs
+++ b/Assets/Scripts/Battle/EnemyEncounter.cs
@@ -157,7 +157,11 @@ public class EnemyEncounter : MonoBehaviour {
         Table luaEnemyTable = script.GetVar("enemies").Table;
 
         for (int i = 0; i < enemyCount; i++) {
-            luaEnemyTable.Set(i + 1, CreateEnemy(enemyScriptsLua.Table.Get(i + 1).String, enemyPositions[i].x, enemyPositions[i].y));
+            string enemyName = enemyScriptsLua.Table.Get(i + 1).String;
+            DynValue enemy = CreateEnemy(enemyName, enemyPositions[i].x, enemyPositions[i].y);
+
+            luaEnemyTable.Set(i + 1, enemy);
+            luaEnemyTable.Set(enemyName, enemy);
         }
 
         script.SetVar("enemies", DynValue.NewTable(luaEnemyTable));


### PR DESCRIPTION
Like `enemies.poseur` or `enemies['poseur']`, besides `enemies[1]`.
I'm not sure where to document this