### PR TITLE
Add the ability to silently use items

### DIFF
--- a/Assets/Mods/Encounter Skeleton/Lua/Encounters/encounter.lua
+++ b/Assets/Mods/Encounter Skeleton/Lua/Encounters/encounter.lua
@@ -38,6 +38,8 @@ function HandleSpare()
     State("ENEMYDIALOGUE")
 end
 
-function HandleItem(ItemID)
-    BattleDialog({"Selected item " .. ItemID .. "."})
+function HandleItem(ItemID, ItemIndex, IsSilent)
+    if not IsSilent then
+        BattleDialog({"Selected item " .. ItemID .. "."})
+    end
 end

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -71,13 +71,13 @@ public static class Inventory {
         return !UnitaleUtil.IsOverworld && UnitaleUtil.TryCall(EnemyEncounter.script, func, param);
     }
 
-    public static void UseItem(int ID) {
+    public static void UseItem(int ID, bool silent = false) {
         usedItemNoDelete = false;
         itemStatAmount = 0;
         string Name = inventory[ID].Name, replacement = "";
         int type = inventory[ID].Type;
         float amount = -991;
-        TryCall("HandleItem", new[] { DynValue.NewString(Name.ToUpper()), DynValue.NewNumber(ID + 1) });
+        TryCall("HandleItem", new[] { DynValue.NewString(Name.ToUpper()), DynValue.NewNumber(ID + 1), DynValue.NewBoolean(silent) });
 
         // Check if the current item has been added to the list of custom items
         bool foundCustomItem = false;
@@ -101,6 +101,9 @@ public static class Inventory {
         } else if (!usedItemNoDelete && type == 0)
             // Delete the item if it's a standard consumable
             inventory.RemoveAt(ID);
+
+        if (silent)
+            return;
 
         if (!UnitaleUtil.IsOverworld) {
             if (!UIController.instance.battleDialogueStarted && mess != null)
@@ -512,7 +515,7 @@ public static class Inventory {
         catch { /* ignored */ }
     }
 
-    private static void SetEquip(int ID) {
+    public static void SetEquip(int ID) {
         string Name = inventory[ID].Name;
         int mode;
 

--- a/Assets/Scripts/Lua/CLRBindings/LuaInventory.cs
+++ b/Assets/Scripts/Lua/CLRBindings/LuaInventory.cs
@@ -13,10 +13,10 @@ public class LuaInventory {
         return -1;
     }
 
-    public void UseItem(int ID) {
+    public void UseItem(int ID, bool silent = false) {
         if (ID < 1) throw new CYFException("Inventory.UseItem: The item's ID must be positive!");
         if (ID > Inventory.inventory.Count) throw new CYFException("Inventory.UseItem: You tried to use the item #" + ID + ", but the player only has " + Inventory.inventory.Count + " items.");
-        Inventory.UseItem(ID - 1);
+        Inventory.UseItem(ID - 1, silent);
     }
 
     public void SetItem(int index, string Name) { Inventory.SetItem(index-1, Name); }

--- a/Documentation CYF 1.0/pages/api-events.html
+++ b/Documentation CYF 1.0/pages/api-events.html
@@ -90,12 +90,13 @@ it's w3c valid, at least
                 </ul>
             </p>
             <p>
-                <br><span class="function">HandleItem(<span class="string"></span> item_ID, <span class="number"></span> position)</span>
+                <br><span class="function">HandleItem(<span class="string"></span> item_ID, <span class="number"></span> position, <span class="boolean"></span> silent)</span>
                 Happens when you select an item from the item menu. <br>
                 <ul>
                     <li><span class="term">item_ID</span>: The name of the item used, <b><u>IN ALL CAPS</u></b>.
                     Similar to <span class="term">HandleCustomCommand</span> in monster scripts.</li>
                     <li><span class="term">position</span>: The position of the item used in the player's inventory. The first item is number 1.</li>
+                    <li><span class="term">silent</span>: If this is true, avoid doing things like writing battle text.</li>
                 </ul>
                 <br><span class="CYF"></span> In CYF, you can use the Inventory object to edit the player's inventory.
                 The items' names will be in caps, like with <span class="term">HandleCustomCommand()</span>.

--- a/Documentation CYF 1.0/pages/cyf-inventory.html
+++ b/Documentation CYF 1.0/pages/cyf-inventory.html
@@ -100,9 +100,10 @@ it's w3c valid, at least
                 <br><span class="term" style="margin-left:20px">name</span> = Name of the item to put in the inventory.
             </p>
             <p>
-                <br><span class="function">Inventory.UseItem(<span class="number"></span> index)</span>
+                <br><span class="function">Inventory.UseItem(<span class="number"></span> index, <span class="boolean"></span> silent)</span>
                 Uses the inventory item at index <span class="term">index</span>. Will throw an error if you have no item at the given index, so check if it exists before using this function.
                 <br><span class="term" style="margin-left:20px">index</span> = Index of the item to use, starting from 1.
+                <br><span class="term" style="margin-left:20px">silent</span> = Whether or not using the item will result in writing battle text.
             </p>
             <p>
                 <br><span class="function">Inventory.AddCustomItems(<span class="luatable"><span class="string"></span></span> names,


### PR DESCRIPTION
Currently, UseItem writes out text, no matter what. This is undesirable if you want it to happen silently, for example if you're making an Overworld engine and need to equip items while loading a save point, or if you have a cutscene where you equip something.

Initially I was thinking of adding an Inventory.EquipItem function, but UseItem handles some equip code for some reason.

Additionally, I've updated the Encounter Skeleton to reflect the new silent mode, hopefully nudging battle creators to use it when necessary.

The documentation has been updated to reflect these changes.