### PR TITLE
TIme.timeScale fixes

### DIFF
--- a/Assets/Scripts/Battle/GameOverBehavior.cs
+++ b/Assets/Scripts/Battle/GameOverBehavior.cs
@@ -116,7 +116,7 @@ public class GameOverBehavior : MonoBehaviour {
     }
 
     private IEnumerator StartDeathRoutine(string[] newDeathText = null, string newDeathMusic = null) {
-        yield return null;
+        yield return new WaitForEndOfFrame();
         isDying = false;
         Time.timeScale = 1;
         PlayerOverworld.audioCurrTime = 0;

--- a/Assets/Scripts/Battle/GameOverBehavior.cs
+++ b/Assets/Scripts/Battle/GameOverBehavior.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using MoonSharp.Interpreter;
 using UnityEngine;
@@ -40,6 +41,7 @@ public class GameOverBehavior : MonoBehaviour {
     private float internalTimer;
     private float internalTimerRevive;
     private float gameOverFadeTimer;
+    private bool isDying;
     private bool started;
     private bool done;
     private bool exiting;
@@ -90,6 +92,8 @@ public class GameOverBehavior : MonoBehaviour {
         internalTimerRevive = 0.0f;
         gameOverFadeTimer = 0.0f;
         gameOverTxt.HideTextObject();
+        StopAllCoroutines();
+        isDying = false;
         started = false;
         done = false;
         exiting = false;
@@ -105,6 +109,16 @@ public class GameOverBehavior : MonoBehaviour {
     public void Revive() { revived = true; }
 
     public void StartDeath(string[] newDeathText = null, string newDeathMusic = null) {
+        if (started || isDying)
+            return;
+        isDying = true;
+        StartCoroutine(StartDeathRoutine(newDeathText, newDeathMusic));
+    }
+
+    private IEnumerator StartDeathRoutine(string[] newDeathText = null, string newDeathMusic = null) {
+        yield return null;
+        isDying = false;
+        Time.timeScale = 1;
         PlayerOverworld.audioCurrTime = 0;
         if (!UnitaleUtil.IsOverworld) {
             UIController.instance.encounter.EndWave(true);

--- a/Assets/Scripts/Lua/ErrorDisplay.cs
+++ b/Assets/Scripts/Lua/ErrorDisplay.cs
@@ -15,6 +15,7 @@ public class ErrorDisplay : MonoBehaviour {
             Destroy(GameObject.Find("Player"));
         }
         UnitaleUtil.firstErrorShown = false;
+        Time.timeScale = 1;
         string mess = !GlobalControls.modDev ? "restart CYF" : "reload";
         GetComponent<Text>().text = Message + "\n\nPress ESC to " + mess;
     }


### PR DESCRIPTION
### Problem 1: If timeScale is changed, it doesn't reset upon error screen.
Fix: Reset timeScale in ErrorDisplay::Start.

### Problem 2: If timeScale is changed, it doesn't reset upon death.
Fix: Reset timeScale in GameOverBehavior::StartDeath.

### Problem 3: If timeScale changes right after player died (in the same frame), it overrides the timeScale reset.
Fix: Delay the game over screen trigger until the end of the current frame.
- Add StartDeathRoutine and move the timeScale reset there.
- Add isDying flag to prevent triggering multiple coroutines.