### PR TITLE
Fix projectile layer name when using a normal layer

### DIFF
--- a/Assets/Scripts/Lua/CLRBindings/ProjectileController.cs
+++ b/Assets/Scripts/Lua/CLRBindings/ProjectileController.cs
@@ -121,7 +121,13 @@ public class ProjectileController {
     public bool isPersistent = false;
 
     public string layer {
-        get { return spr.img.transform.parent.name == "BulletPool" ? "" : spr.img.transform.parent.name.Substring(0, spr.img.transform.parent.name.Length - 6); }
+        get {
+            string parentName = spr.img.transform.parent.name;
+            if (parentName == "BulletPool") return "";
+            if (parentName.EndsWith("Bullet")) return parentName.Substring(0, parentName.Length - 6);
+            if (parentName.EndsWith("Layer")) return parentName.Substring(0, parentName.Length - 5);
+            return parentName;
+        }
         set {
             Transform parent = spr.img.transform.parent;
             try {


### PR DESCRIPTION
Problem: Projectile.layer returns a broken value if the projectile is created on normal layer instead of a custom projectile layer.
Example:
```lua
local test = CreateProjectile('bullet', 1, 1, 'BelowArena')
DEBUG(test.layer) -- BelowAren
```
Fix: Correctly truncate the projectile layer name depending on whether it's a normal layer or a projectile layer.