### PR TITLE
Add control over player's centering in the arena

### DIFF
--- a/Assets/Scripts/Battle/UIController.cs
+++ b/Assets/Scripts/Battle/UIController.cs
@@ -291,7 +291,9 @@ public class UIController : MonoBehaviour {
         if (newState == "DEFENDING" || newState == "ENEMYDIALOGUE") {
             PlayerController.instance.setControlOverride(newState != "DEFENDING");
             mainTextManager.SetText(DynValue.NewString(""));
-            PlayerController.instance.SetPosition(ArenaManager.instance.currentX, ArenaManager.instance.currentY + 70, true);
+            if (PlayerController.instance.autocenter) {
+                PlayerController.instance.SetPosition(ArenaManager.instance.currentX, ArenaManager.instance.currentY + 70, true);
+            }
             PlayerController.instance.GetComponent<Image>().enabled = true;
             mainTextManager.SetPause(true);
         } else if ((state == "DEFENDING" || state == "ENEMYDIALOGUE") && newState != "DEFENDING" && newState != "ENEMYDIALOGUE") {

--- a/Assets/Scripts/Battle/UIController.cs
+++ b/Assets/Scripts/Battle/UIController.cs
@@ -291,7 +291,7 @@ public class UIController : MonoBehaviour {
         if (newState == "DEFENDING" || newState == "ENEMYDIALOGUE") {
             PlayerController.instance.setControlOverride(newState != "DEFENDING");
             mainTextManager.SetText(DynValue.NewString(""));
-            if (PlayerController.instance.autocenter) {
+            if (PlayerController.instance.ShouldAutoCenter(state)) {
                 PlayerController.instance.SetPosition(ArenaManager.instance.currentX, ArenaManager.instance.currentY + 70, true);
             }
             PlayerController.instance.GetComponent<Image>().enabled = true;

--- a/Assets/Scripts/Lua/CLRBindings/LuaPlayerStatus.cs
+++ b/Assets/Scripts/Lua/CLRBindings/LuaPlayerStatus.cs
@@ -190,6 +190,14 @@ public class LuaPlayerStatus {
     }
 
     /// <summary>
+    /// Move player to the center of the arena when entering DEFENDING or ENEMYDIALOGUE
+    /// </summary>
+    public bool autocenter {
+        get { return player.autocenter; }
+        set { player.autocenter = value; }
+    }
+
+    /// <summary>
     /// Hurts the player with the given damage and invulnerabilty time. If this gets the player to 0 (or less) HP, you get the game over screen.
     /// </summary>
     /// <param name="damage">Damage to deal to the player</param>

--- a/Assets/Scripts/Lua/CLRBindings/LuaPlayerStatus.cs
+++ b/Assets/Scripts/Lua/CLRBindings/LuaPlayerStatus.cs
@@ -1,4 +1,6 @@
-﻿/// <summary>
+﻿using MoonSharp.Interpreter;
+
+/// <summary>
 /// Lua binding to set and retrieve information for the on-screen player.
 /// </summary>
 public class LuaPlayerStatus {
@@ -190,9 +192,11 @@ public class LuaPlayerStatus {
     }
 
     /// <summary>
-    /// Move player to the center of the arena when entering DEFENDING or ENEMYDIALOGUE
+    /// Controls when the player is automatically moved to the center of the arena upon entering DEFENDING or ENEMYDIALOGUE.
+    /// Accepts either a boolean (true always centers, false never centers) or a table of strings. When a table is given,
+    /// centering only happens if the previous state matches one of its entries. nil is treated as true.
     /// </summary>
-    public bool autocenter {
+    public DynValue autocenter {
         get { return player.autocenter; }
         set { player.autocenter = value; }
     }

--- a/Assets/Scripts/PlayerControllers/PlayerController.cs
+++ b/Assets/Scripts/PlayerControllers/PlayerController.cs
@@ -122,9 +122,30 @@ public class PlayerController : MonoBehaviour {
     private int soundDelay;
 
     /// <summary>
-    /// Move player to the center of the arena when entering DEFENDING or ENEMYDIALOGUE
+    /// Controls when the player is automatically moved to the center of the arena upon entering DEFENDING or ENEMYDIALOGUE.
+    /// Accepts either a boolean (true always centers, false never centers) or a table of strings. When a table is given,
+    /// centering only happens if the previous state matches one of its entries. nil is treated as true.
     /// </summary>
-    public bool autocenter = true;
+    public DynValue autocenter = DynValue.NewBoolean(true);
+
+    public bool ShouldAutoCenter(string fromState) {
+        DynValue value = autocenter;
+
+        if (value == null || value.IsNil())
+            return true;
+
+        if (value.Type == DataType.Boolean)
+            return value.Boolean;
+
+        if (value.Type == DataType.Table) {
+            foreach (TablePair pair in value.Table.Pairs)
+                if (pair.Value.String == fromState)
+                    return true;
+            return false;
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Hurts the player and makes them invulnerable for invulnerabilitySeconds.

--- a/Assets/Scripts/PlayerControllers/PlayerController.cs
+++ b/Assets/Scripts/PlayerControllers/PlayerController.cs
@@ -122,6 +122,11 @@ public class PlayerController : MonoBehaviour {
     private int soundDelay;
 
     /// <summary>
+    /// Move player to the center of the arena when entering DEFENDING or ENEMYDIALOGUE
+    /// </summary>
+    public bool autocenter = true;
+
+    /// <summary>
     /// Hurts the player and makes them invulnerable for invulnerabilitySeconds.
     /// </summary>
     /// <param name="damage">Damage to deal to the player.</param>

--- a/Documentation CYF 1.0/js/SideBar.js
+++ b/Documentation CYF 1.0/js/SideBar.js
@@ -146,7 +146,7 @@ const isNew = [
     "The Text Object", "The Arena Object", "The UI Object",
     "Projectile Management", "Sprites &amp; Animation",
     "General Objects", "Item List", "Key List",
-    "The Input Object" ];
+    "The Input Object", "The Player Object"];
 
 // Categories with a <CYF> prefix
 // Used for categories only added during CYF's development

--- a/Documentation CYF 1.0/pages/api-functions-player.html
+++ b/Documentation CYF 1.0/pages/api-functions-player.html
@@ -105,10 +105,11 @@ it's w3c valid, at least
                 Will always be false while not in a wave script.
                 <br>NOTE: This only will change with the default control scheme (see <span class="term">Player.SetControlOverride</span> below).
                 </li><br>
-                <li><span class="new boolean"></span><span class="CYF"></span> <span class="term">Player.autocenter</span> - Automatically move the player to the center of the arena when entering <span class="term">DEFENDING</span> or <span class="term">ENEMYDIALOGUE</span>. <span class="term">true</span> by default.
-                    <br><br>Set it to <span class="term">false</span> to disable auto-centering entirely, or to a table of state names (for example,
-                    <span class="term">Player.autocenter = {"ATTACKING", "DEFENDING"}</span>) to center the player only when
-                    transitioning from one of those listed states.
+                <li><span class="new boolean"></span><span class="CYF"></span> <span class="term">Player.autocenter</span> - Automatically move the player to the center of the arena when entering <span class="term">DEFENDING</span> or <span class="term">ENEMYDIALOGUE</span>.
+                    <span class="term">true</span> by default.
+                    <br><br>Set it to <span class="term">false</span> to disable auto-centering entirely, or to a table of state names to center the player only when transitioning from one of those listed states.
+                    <br><br>For example, if you just want to prevent the player's soul centering when transitioning from one wave to another, set
+                    <span class="term">Player.autocenter = {"ATTACKING", "DIALOGRESULT", "MERCYMENU", "ITEMMENU"}</span> to cover only normal cases.
                 </li><br>
                 <li><span class="term">Player.Hurt(<span class="number"></span> damage, <span class="number"></span> invul_time = 1.7, <span class="boolean"></span> ignoreDef = false, <span class="boolean"></span> playSound = true)</span>
                 - deals damage to the player, and makes them invincible for <span class="term">invul_time</span> seconds.

--- a/Documentation CYF 1.0/pages/api-functions-player.html
+++ b/Documentation CYF 1.0/pages/api-functions-player.html
@@ -105,7 +105,10 @@ it's w3c valid, at least
                 Will always be false while not in a wave script.
                 <br>NOTE: This only will change with the default control scheme (see <span class="term">Player.SetControlOverride</span> below).
                 </li><br>
-                <li><span class="boolean"></span> <span class="term">Player.autocenter</span> - Automatically move the player to the center of the arena when entering <span class="term">DEFENDING</span> or <span class="term">ENEMYDIALOGUE</span>. True by default.
+                <li><span class="new boolean"></span><span class="CYF"></span> <span class="term">Player.autocenter</span> - Automatically move the player to the center of the arena when entering <span class="term">DEFENDING</span> or <span class="term">ENEMYDIALOGUE</span>. <span class="term">true</span> by default.
+                    <br><br>Set it to <span class="term">false</span> to disable auto-centering entirely, or to a table of state names (for example,
+                    <span class="term">Player.autocenter = {"ATTACKING", "DEFENDING"}</span>) to center the player only when
+                    transitioning from one of those listed states.
                 </li><br>
                 <li><span class="term">Player.Hurt(<span class="number"></span> damage, <span class="number"></span> invul_time = 1.7, <span class="boolean"></span> ignoreDef = false, <span class="boolean"></span> playSound = true)</span>
                 - deals damage to the player, and makes them invincible for <span class="term">invul_time</span> seconds.

--- a/Documentation CYF 1.0/pages/api-functions-player.html
+++ b/Documentation CYF 1.0/pages/api-functions-player.html
@@ -105,6 +105,8 @@ it's w3c valid, at least
                 Will always be false while not in a wave script.
                 <br>NOTE: This only will change with the default control scheme (see <span class="term">Player.SetControlOverride</span> below).
                 </li><br>
+                <li><span class="boolean"></span> <span class="term">Player.autocenter</span> - Automatically move the player to the center of the arena when entering <span class="term">DEFENDING</span> or <span class="term">ENEMYDIALOGUE</span>. True by default.
+                </li><br>
                 <li><span class="term">Player.Hurt(<span class="number"></span> damage, <span class="number"></span> invul_time = 1.7, <span class="boolean"></span> ignoreDef = false, <span class="boolean"></span> playSound = true)</span>
                 - deals damage to the player, and makes them invincible for <span class="term">invul_time</span> seconds.
                 <br>Can not hurt the player again if they are already hurting (flashing).

--- a/Documentation CYF 1.0/pages/api-functions-player.html
+++ b/Documentation CYF 1.0/pages/api-functions-player.html
@@ -105,7 +105,7 @@ it's w3c valid, at least
                 Will always be false while not in a wave script.
                 <br>NOTE: This only will change with the default control scheme (see <span class="term">Player.SetControlOverride</span> below).
                 </li><br>
-                <li><span class="new boolean"></span><span class="CYF"></span> <span class="term">Player.autocenter</span> - Automatically move the player to the center of the arena when entering <span class="term">DEFENDING</span> or <span class="term">ENEMYDIALOGUE</span>.
+                <li><span class="new"></span><span class="boolean"> or <span class="luatable"><span class="string"></span></span><span class="CYF"></span> <span class="term">Player.autocenter</span> - Automatically move the player to the center of the arena when entering <span class="term">DEFENDING</span> or <span class="term">ENEMYDIALOGUE</span>.
                     <span class="term">true</span> by default.
                     <br><br>Set it to <span class="term">false</span> to disable auto-centering entirely, or to a table of state names to center the player only when transitioning from one of those listed states.
                     <br><br>For example, if you just want to prevent the player's soul centering when transitioning from one wave to another, set


### PR DESCRIPTION
Add `Player.autocenter` to let us disable automatic centering of the player's soul when entering defending or enemydialogue. Useful when you want make a seamless transition between two waves.