### PR TITLE
Add interrupt parameter to NewAudio.PlaySound/PlayVoice

### DIFF
--- a/Assets/Scripts/Lua/CLRBindings/NewMusicManager.cs
+++ b/Assets/Scripts/Lua/CLRBindings/NewMusicManager.cs
@@ -82,36 +82,54 @@ public class NewMusicManager {
         ((AudioSource)audiolist[name]).Play();
     }
 
-    public static void PlaySound(string name, string sound, bool loop = false, float volume = 0.65f) {
+    public static void PlaySound(string name, string sound, bool loop = false, float volume = 0.65f, bool interrupt = true) {
         if (name == null)  throw new CYFException("NewAudio.PlaySound: The first argument (the channel name) is nil.\n\nSee the documentation for proper usage.");
         if (sound == null) throw new CYFException("NewAudio.PlaySound: The second argument (the sound name) is nil.\n\nSee the documentation for proper usage.");
         if (!audiolist.ContainsKey(name)) throw new CYFException("The audio channel " + name + " doesn't exist.");
 
-        ((AudioSource)audiolist[name]).Stop();
-        ((AudioSource)audiolist[name]).loop = loop;
-        ((AudioSource)audiolist[name]).volume = volume;
-        ((AudioSource)audiolist[name]).clip = AudioClipRegistry.GetSound(sound);
-        audiolist[name] = ((AudioSource)audiolist[name]);
-        audioname[name] = "sound:" + sound.ToLower();
-        if (name == "src")
-            MusicManager.filename = "sound:" + sound.ToLower();
-        ((AudioSource)audiolist[name]).Play();
+        AudioSource source = (AudioSource)audiolist[name];
+        if (interrupt) {
+            source.Stop();
+            source.loop = loop;
+            source.volume = volume;
+            source.clip = AudioClipRegistry.GetSound(sound);
+            audioname[name] = "sound:" + sound.ToLower();
+            if (name == "src")
+                MusicManager.filename = "sound:" + sound.ToLower();
+            source.Play();
+        } else {
+            source.volume = volume;
+            source.loop = loop;
+            source.PlayOneShot(AudioClipRegistry.GetSound(sound), volume);
+            audioname[name] = "sound:" + sound.ToLower();
+            if (name == "src")
+                MusicManager.filename = "sound:" + sound.ToLower();
+        }
     }
 
-    public static void PlayVoice(string name, string voice, bool loop = false, float volume = 0.65f) {
+    public static void PlayVoice(string name, string voice, bool loop = false, float volume = 0.65f, bool interrupt = true) {
         if (name == null)  throw new CYFException("NewAudio.PlayVoice: The first argument (the channel name) is nil.\n\nSee the documentation for proper usage.");
         if (voice == null) throw new CYFException("NewAudio.PlayVoice: The second argument (the voice name) is nil.\n\nSee the documentation for proper usage.");
         if (!audiolist.ContainsKey(name)) throw new CYFException("The audio channel " + name + " doesn't exist.");
 
-        ((AudioSource)audiolist[name]).Stop();
-        ((AudioSource)audiolist[name]).loop = loop;
-        ((AudioSource)audiolist[name]).volume = volume;
-        ((AudioSource)audiolist[name]).clip = AudioClipRegistry.GetVoice(voice);
-        audiolist[name] = ((AudioSource)audiolist[name]);
-        audioname[name] = "voice:" + voice.ToLower();
-        if (name == "src")
-            MusicManager.filename = "voice:" + voice.ToLower();
-        ((AudioSource)audiolist[name]).Play();
+        AudioSource source = (AudioSource)audiolist[name];
+        if (interrupt) {
+            source.Stop();
+            source.loop = loop;
+            source.volume = volume;
+            source.clip = AudioClipRegistry.GetVoice(voice);
+            audioname[name] = "voice:" + voice.ToLower();
+            if (name == "src")
+                MusicManager.filename = "voice:" + voice.ToLower();
+            source.Play();
+        } else {
+            source.volume = volume;
+            source.loop = loop;
+            source.PlayOneShot(AudioClipRegistry.GetVoice(voice), volume);
+            audioname[name] = "voice:" + voice.ToLower();
+            if (name == "src")
+                MusicManager.filename = "voice:" + voice.ToLower();
+        }
     }
 
     public static void SetPitch(string name, float value) {

--- a/Documentation CYF 1.0/js/SideBar.js
+++ b/Documentation CYF 1.0/js/SideBar.js
@@ -145,7 +145,7 @@ const isNew = [
     "Special Variables", "Text Commands", "Game Events",
     "The Text Object", "The Arena Object", "The UI Object",
     "Projectile Management", "Sprites &amp; Animation",
-    "General Objects", "Item List", "Key List",
+    "General Objects", "Item List", "Key List", "The NewAudio Object",
     "The Input Object" ];
 
 // Categories with a <CYF> prefix

--- a/Documentation CYF 1.0/pages/api-functions-newaudio.html
+++ b/Documentation CYF 1.0/pages/api-functions-newaudio.html
@@ -70,20 +70,22 @@ it's w3c valid, at least
                 Songs played are loaded from your mod's <span class="term">Audio</span> folder, as .ogg or .wav files. Don't include the file extension.</li><br>
 
                 <li><span class="term">NewAudio.PlaySound(<span class="string"></span> name, <span class="string"></span> sound,
-                <span class="boolean"></span> loop = false, <span class="number"></span> volume = 0.65)</span> - Plays the sound
+                <span class="boolean"></span> loop = false, <span class="number"></span> volume = 0.65, <span class="boolean"></span> interrupt = true)</span> - Plays the sound
                 <span class="term">sound</span> on the channel <span class="term">name</span>.
                 <br><br>
                 <span class="term">loop</span> tells the engine if it should loop the sound or not;<br>
-                <span class="term">volume</span> is the volume of the sound.
+                <span class="term">volume</span> is the volume of the sound;<br>
+                <span class="term">interrupt</span> determines whether previously playing sounds on the channel should be stopped.
                 <br><br>
                 Sounds played are loaded from your mod's <span class="term">Sounds</span> folder, as .ogg or .wav files. Don't include the file extension.</li><br>
 
                 <li><span class="term">NewAudio.PlayVoice(<span class="string"></span> name, <span class="string"></span> voice,
-                <span class="boolean"></span> loop = false, <span class="number"></span> volume = 0.65)</span> - Plays the voice
+                <span class="boolean"></span> loop = false, <span class="number"></span> volume = 0.65, <span class="boolean"></span> interrupt = true)</span> - Plays the voice
                 <span class="term">voice</span> on the channel <span class="term">name</span>.
                 <br><br>
                 <span class="term">loop</span> tells the engine if it should loop the voice or not;<br>
-                <span class="term">volume</span> is the volume of the voice.
+                <span class="term">volume</span> is the volume of the voice;<br>
+                <span class="term">interrupt</span> determines whether previously playing sounds on the channel should be stopped.
                 <br><br>
                 Voices played are loaded from your mod's <span class="term">Sounds/Voices</span> folder, as .ogg or .wav files. Don't include the file extension.</li><br>
 

--- a/Documentation CYF 1.0/pages/api-functions-newaudio.html
+++ b/Documentation CYF 1.0/pages/api-functions-newaudio.html
@@ -70,8 +70,8 @@ it's w3c valid, at least
                 Songs played are loaded from your mod's <span class="term">Audio</span> folder, as .ogg or .wav files. Don't include the file extension.</li><br>
 
                 <li><span class="term">NewAudio.PlaySound(<span class="string"></span> name, <span class="string"></span> sound,
-                <span class="boolean"></span> loop = false, <span class="number"></span> volume = 0.65, <span class="boolean"></span> interrupt = true)</span> - Plays the sound
-                <span class="term">sound</span> on the channel <span class="term">name</span>.
+                <span class="boolean"></span> loop = false, <span class="number"></span> volume = 0.65, <span class="new"></span><span class="boolean"></span> interrupt = true)</span>
+                - Plays the sound <span class="term">sound</span> on the channel <span class="term">name</span>.
                 <br><br>
                 <span class="term">loop</span> tells the engine if it should loop the sound or not;<br>
                 <span class="term">volume</span> is the volume of the sound;<br>
@@ -80,8 +80,8 @@ it's w3c valid, at least
                 Sounds played are loaded from your mod's <span class="term">Sounds</span> folder, as .ogg or .wav files. Don't include the file extension.</li><br>
 
                 <li><span class="term">NewAudio.PlayVoice(<span class="string"></span> name, <span class="string"></span> voice,
-                <span class="boolean"></span> loop = false, <span class="number"></span> volume = 0.65, <span class="boolean"></span> interrupt = true)</span> - Plays the voice
-                <span class="term">voice</span> on the channel <span class="term">name</span>.
+                <span class="boolean"></span> loop = false, <span class="number"></span> volume = 0.65, <span class="new"></span><span class="boolean"></span> interrupt = true)</span>
+                - Plays the voice <span class="term">voice</span> on the channel <span class="term">name</span>.
                 <br><br>
                 <span class="term">loop</span> tells the engine if it should loop the voice or not;<br>
                 <span class="term">volume</span> is the volume of the voice;<br>


### PR DESCRIPTION
Unlike Audio.PlaySound, NewAudio.PlaySound interrupts any actively playing audio on the channel. Added an option to prevent that.