### PR TITLE
Expose Arena.innerSprite and Arena.outerSprite in Lua

### DIFF
--- a/Assets/Scripts/Battle/ArenaManager.cs
+++ b/Assets/Scripts/Battle/ArenaManager.cs
@@ -45,12 +45,24 @@ public class ArenaManager : MonoBehaviour {
         inner = outer.GetChild(outer.childCount - 1).GetComponent<RectTransform>();
         innerSprite = LuaSpriteController.GetOrCreate(GameObject.Find("arena"));
         outerSprite = LuaSpriteController.GetOrCreate(GameObject.Find("arena_border_outer"));
+
+        // To be able to use Arena.innerSprite/outerSprite.Mask()
+        AddMaskComponents(innerSprite);
+        AddMaskComponents(outerSprite);
+
         desiredX = outer.position.x;
         desiredY = outer.position.y;
         desiredWidth = currentWidth;
         desiredHeight = currentHeight;
         instance = this;
         luaStatus = new LuaArenaStatus();
+    }
+
+    private void AddMaskComponents(LuaSpriteController sprite) {
+        Mask mask = sprite.img.AddComponent<Mask>();
+        mask.enabled = false;
+        RectMask2D box = sprite.img.AddComponent<RectMask2D>();
+        box.enabled = false;
     }
 
     private void Start() {

--- a/Assets/Scripts/Lua/CLRBindings/LuaArenaStatus.cs
+++ b/Assets/Scripts/Lua/CLRBindings/LuaArenaStatus.cs
@@ -23,6 +23,13 @@ public class LuaArenaStatus {
     public bool isModifying { get { return isMoving || isResizing;                     } }
     public bool ismodifying { get { return isModifying; } }
 
+    public LuaSpriteController innerSprite {
+        get { return ArenaManager.instance.innerSprite; }
+    }
+    public LuaSpriteController outerSprite {
+        get { return ArenaManager.instance.outerSprite; }
+    }
+
     public float[] innerColor {
         get { return ArenaManager.instance.innerSprite.color; }
         set { ArenaManager.instance.innerSprite.color = value; }

--- a/Documentation CYF 1.0/pages/api-functions-waves.html
+++ b/Documentation CYF 1.0/pages/api-functions-waves.html
@@ -73,6 +73,10 @@ it's w3c valid, at least
                 NOTE: <span class="term">Arena.currenty</span> is the position of the bottom of the <i>inside</i> (black part) of the Arena. It will be 5 pixels (the
                 arena's width) greater than <span class="term">Arena.y</span>.
                 </li><br>
+
+                <li><span class="CYF"></span> <span class="userdata">sprite</span> Arena.innerSprite - The inner layer of the Arena (the space within the borders).</li><br>
+                <li><span class="CYF"></span> <span class="userdata">sprite</span> Arena.outerSprite - The outer layer of the Arena (including borders and enemies).</li><br>
+
                 <li><span class="CYF"></span> <span class="luatable"><span class="number"></span>, <span class="number"></span>, <span class="number"></span>, <span class="number"></span> = 1 </span> <span class="term">Arena.innerColor</span>
                 - Set RGBA color (0-1) of Arena's inner sprite.</li><br>
 


### PR DESCRIPTION
Expose Arena.innerSprite and Arena.outerSprite in Lua. Now you don't need to create and manage an extra arena sprite to parent your bullets to.