### PR TITLE
Text object fixes and improvements

### DIFF
--- a/Assets/Scripts/Lua/CLRBindings/LuaTextManager.cs
+++ b/Assets/Scripts/Lua/CLRBindings/LuaTextManager.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.UI;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -355,6 +356,7 @@ public class LuaTextManager : TextManager {
 
     [MoonSharpHidden] public Color _color = Color.white;
     [MoonSharpHidden] public bool textColorSet, textAlphaSet;
+    [MoonSharpHidden] public Color _bubbleColor = Color.white;
     // The color of the text. It uses an array of three floats between 0 and 1
     public float[] color {
         get {
@@ -436,6 +438,53 @@ public class LuaTextManager : TextManager {
         }
     }
 
+
+    public float[] bubbleColor {
+        get {
+            CheckExists();
+            return new[] { _bubbleColor.r, _bubbleColor.g, _bubbleColor.b };
+        }
+        set {
+            CheckExists();
+            if (value == null)
+                throw new CYFException("text.bubbleColor can not be set to a nil value.");
+            if (value.Length != 3)
+                throw new CYFException("You need 3 numeric values when setting a text's bubble color.");
+
+            _bubbleColor.r = value[0];
+            _bubbleColor.g = value[1];
+            _bubbleColor.b = value[2];
+
+            ApplyBubbleColor();
+        }
+    }
+
+    public float[] bubbleColor32 {
+        get {
+            CheckExists();
+            return new float[] { ((Color32)_bubbleColor).r, ((Color32)_bubbleColor).g, ((Color32)_bubbleColor).b };
+        }
+        set {
+            CheckExists();
+            if (value == null)
+                throw new CYFException("text.bubbleColor32 can not be set to a nil value.");
+            if (value.Length != 3)
+                throw new CYFException("You need 3 numeric values when setting a text's bubble color.");
+            bubbleColor = value.Select(v => v / 255).ToArray();
+        }
+    }
+
+    private void ApplyBubbleColor() {
+        if (containerBubble == null)
+            return;
+        foreach (Image img in containerBubble.GetComponentsInChildren<Image>(true)) {
+            // The black outer borders and the tail's shadow must stay black
+            string n = img.name;
+            if (n == "BackHorz" || n == "BackVert" || n.Contains("Shadow"))
+                continue;
+            img.color = new Color(_bubbleColor.r, _bubbleColor.g, _bubbleColor.b, img.color.a);
+        }
+    }
 
     public string linePrefix {
         get {

--- a/Assets/Scripts/Lua/CLRBindings/LuaTextManager.cs
+++ b/Assets/Scripts/Lua/CLRBindings/LuaTextManager.cs
@@ -509,6 +509,18 @@ public class LuaTextManager : TextManager {
         }
     }
 
+    private DynValue _OnTextComplete = DynValue.Nil;
+    public DynValue OnTextComplete {
+        get { return _OnTextComplete; }
+        set {
+            if ((value.Type & (DataType.Nil | DataType.Function | DataType.ClrFunction)) == 0)
+                throw new CYFException("Text.OnTextComplete: This variable has to be a function!");
+            if (value.Type == DataType.Function && value.Function.OwnerScript != caller.script)
+                throw new CYFException("Text.OnTextComplete: You can only use a function created in the same script as the text object!");
+            _OnTextComplete = value;
+        }
+    }
+
     public DynValue GetLetters() {
         CheckExists();
         if (lateStartWaiting)
@@ -717,6 +729,10 @@ public class LuaTextManager : TextManager {
     public void NextLine() {
         CheckExists();
         if (AllLinesComplete() || currentLine + 1 == LineCount()) {
+            if ((OnTextComplete.Type & (DataType.Function | DataType.ClrFunction)) != 0)
+                caller.Call(OnTextComplete, "OnTextComplete", UserData.Create(this));
+            else if (GlobalControls.isInFight && (EnemyEncounter.script.script.Globals.Get("OnTextComplete").Type & (DataType.Function | DataType.ClrFunction)) != 0)
+                EnemyEncounter.script.Call("OnTextComplete", UserData.Create(this));
             if (!deleteWhenFinished) {
                 HideTextObject();
                 if (bubble)

--- a/Assets/Scripts/Text/TextManager.cs
+++ b/Assets/Scripts/Text/TextManager.cs
@@ -818,7 +818,7 @@ public class TextManager : MonoBehaviour {
             else                                                               return;
         }
 
-        letterTimer += Time.deltaTime;
+        letterTimer += Time.unscaledDeltaTime;
         if ((letterTimer >= timePerLetter || firstChar) && !LineComplete()) {
             int repeats = timePerLetter == 0f ? 1 : (int)Mathf.Floor(letterTimer / timePerLetter);
 

--- a/Assets/Scripts/Text/TextManager.cs
+++ b/Assets/Scripts/Text/TextManager.cs
@@ -371,6 +371,8 @@ public class TextManager : MonoBehaviour {
         instantCommand   = false;
         skipFromPlayer   = false;
         firstChar        = false;
+        waitingChar      = KeyCode.None;
+        waitingKeybind   = null;
         lineHasMugshot   = mugshotList != null;
         commandVoice     = null;
 
@@ -823,31 +825,33 @@ public class TextManager : MonoBehaviour {
             else                                                               return;
         }
 
-        letterTimer += Time.unscaledDeltaTime;
-        if ((letterTimer >= timePerLetter || firstChar) && !LineComplete()) {
-            int repeats = timePerLetter == 0f ? 1 : (int)Mathf.Floor(letterTimer / timePerLetter);
+        letterTimer += Time.deltaTime;
+        bool soundPlayed = firstChar && lettersToDisplay > 1;
+        int lastLetter = -1;
 
-            bool soundPlayed = firstChar && lettersToDisplay > 1;
-            int lastLetter = -1;
-
-            for (int i = 0; i < repeats; i++) {
-                if (lettersToDisplayOnce > 0)
-                    HandleShowLettersOnce(ref soundPlayed, ref lastLetter);
-                else
-                    for (int j = 0; j < lettersToDisplay; j++)
-                        if (!HandleShowLetter(ref soundPlayed, ref lastLetter))
-                            break;
-
-                if (letterTimer < timePerLetter)
-                    break;
-
-                if (!firstChar)
-                    letterTimer -= timePerLetter;
-                else {
-                    firstChar = false;
-                    return;
+        while ((firstChar || letterTimer >= timePerLetter) && !LineComplete()) {
+            if (lettersToDisplayOnce > 0)
+                HandleShowLettersOnce(ref soundPlayed, ref lastLetter);
+            else {
+                int shown = 0;
+                for (int j = 0; j < lettersToDisplay; j++) {
+                    if (!HandleShowLetter(ref soundPlayed, ref lastLetter))
+                        break;
+                    shown++;
                 }
+                if (shown == 0)
+                    break;
             }
+
+            if (firstChar) {
+                firstChar = false;
+                break;
+            }
+
+            if (timePerLetter > 0f)
+                letterTimer -= timePerLetter;
+            else
+                break;
         }
     }
 

--- a/Assets/Scripts/Text/TextManager.cs
+++ b/Assets/Scripts/Text/TextManager.cs
@@ -576,6 +576,11 @@ public class TextManager : MonoBehaviour {
         ltrImg.color = resultColor;
         ltrImg.enabled = textQueue[currentLine].ShowImmediate || (GlobalControls.retroMode && instantActive);
 
+        // For immediately-displayed text (e.g. enemy command lists), apply the letter
+        // effect as each letter is created, since HandleShowLetter never runs for them.
+        if (textQueue[currentLine].ShowImmediate)
+            ApplyLetterEffect(ltrImg);
+
         return letters.Count - 1;
     }
 
@@ -873,15 +878,7 @@ public class TextManager : MonoBehaviour {
             Image im = letters.Find(l => l.index == currentCharacter).image;
             if (im == null) return false;
             im.enabled = true;
-            letterEffectStepCount += letterEffectStep;
-            if (im.GetComponent<Letter>().effect != null)
-                im.GetComponent<Letter>().effect.ResetPositions();
-            switch (letterEffect.ToLower()) {
-                case "twitch": im.GetComponent<Letter>().effect = new TwitchEffectLetter(im.GetComponent<Letter>(), letterIntensity, (int)letterEffectStep);   break;
-                case "rotate": im.GetComponent<Letter>().effect = new RotatingEffectLetter(im.GetComponent<Letter>(), letterIntensity, letterEffectStepCount); break;
-                case "shake":  im.GetComponent<Letter>().effect = new ShakeEffectLetter(im.GetComponent<Letter>(), letterIntensity);                           break;
-                default:       im.GetComponent<Letter>().effect = null;                                                                                        break;
-            }
+            ApplyLetterEffect(im);
 
             currentReferenceCharacter++;
         }
@@ -894,6 +891,19 @@ public class TextManager : MonoBehaviour {
 
         currentCharacter++;
         return true;
+    }
+
+    private void ApplyLetterEffect(Image im) {
+        letterEffectStepCount += letterEffectStep;
+        Letter letter = im.GetComponent<Letter>();
+        if (letter.effect != null)
+            letter.effect.ResetPositions();
+        switch (letterEffect.ToLower()) {
+            case "twitch": letter.effect = new TwitchEffectLetter(letter, letterIntensity, (int)letterEffectStep);   break;
+            case "rotate": letter.effect = new RotatingEffectLetter(letter, letterIntensity, letterEffectStepCount); break;
+            case "shake":  letter.effect = new ShakeEffectLetter(letter, letterIntensity);                           break;
+            default:       letter.effect = null;                                                                      break;
+        }
     }
 
     private void PreCreateControlCommand(string command, bool movementCommand = false) {
@@ -975,6 +985,10 @@ public class TextManager : MonoBehaviour {
             case "effect":
                 float step = args.Length > 2 ? ParseUtil.GetFloat(args[2]) : 0;
                 SetEffect(cmds[1].ToLower(), args.Length > 1 ? ParseUtil.GetFloat(args[1]) : -1, step);
+                break;
+
+            case "lettereffect":
+                SetLetterEffect(args);
                 break;
 
             case "mugshot":
@@ -1218,24 +1232,28 @@ public class TextManager : MonoBehaviour {
                 break;
 
             case "lettereffect":
-                letterEffect = args[0];
-
-                if (args.Length > 1) {
-                    try { letterIntensity = ParseUtil.GetFloat(args[1]); }
-                    catch { Debug.LogError("[lettereffect:x] usage - You used the value \"" + args[1] + "\" to set the letter effect's intensity, but it's not a valid number value."); }
-                } else
-                    letterIntensity = 0;
-
-                if (args.Length > 2) {
-                    try {
-                        letterEffectStep = ParseUtil.GetFloat(args[2]);
-                        letterEffectStepCount = 0;
-                    } catch { Debug.LogError("[lettereffect:x] usage - You used the value \"" + args[2] + "\" to set the letter effect's step, but it's not a valid number value."); }
-                } else {
-                    letterEffectStep = 0;
-                    letterEffectStepCount = 0;
-                }
+                SetLetterEffect(args);
                 break;
+        }
+    }
+
+    private void SetLetterEffect(string[] args) {
+        letterEffect = args[0];
+
+        if (args.Length > 1) {
+            try { letterIntensity = ParseUtil.GetFloat(args[1]); }
+            catch { Debug.LogError("[lettereffect:x] usage - You used the value \"" + args[1] + "\" to set the letter effect's intensity, but it's not a valid number value."); }
+        } else
+            letterIntensity = 0;
+
+        if (args.Length > 2) {
+            try {
+                letterEffectStep = ParseUtil.GetFloat(args[2]);
+                letterEffectStepCount = 0;
+            } catch { Debug.LogError("[lettereffect:x] usage - You used the value \"" + args[2] + "\" to set the letter effect's step, but it's not a valid number value."); }
+        } else {
+            letterEffectStep = 0;
+            letterEffectStepCount = 0;
         }
     }
 

--- a/Documentation CYF 1.0/pages/api-text.html
+++ b/Documentation CYF 1.0/pages/api-text.html
@@ -145,8 +145,7 @@ it's w3c valid, at least
                 This works the same as <span class="term">[effect:x]</span>, but it works <b>inline</b>.
                 This means you can have <i>multiple</i> different text effects in a single line!
                 <br><br>
-                Keep in mind that, like all other inline text commands, this command will not execute if the player skips over it with X -
-                unless you set <span class="term">playerskipdocommand</span> to <span class="term">true</span>, first.
+                This command ignores the <span class="term">playerskipdocommand</span> setting and runs even when text is skipped or displayed instantly.
                 <br><br>
                 <span class="new">On top of that, the default step value for the shake effect is now 500. The value will be varied by about
                 <span class="term">80%</span> every time the delay until the next twitch effect show up is computed. It's high

--- a/Documentation CYF 1.0/pages/cyf-text.html
+++ b/Documentation CYF 1.0/pages/cyf-text.html
@@ -290,6 +290,16 @@ end
                 script, it will call it with the text object as its argument.
             </p>
             <p>
+                <br><span class="new function"><span class="userdata">function</span> Text.OnTextComplete(<span class="userdata">text</span> text)</span>
+                This function gets called whenever the text object finishes displaying all of its lines (i.e. when it would
+                be deactivated or destroyed). This is the best place to run code that should happen once the text is done being shown.
+                <br><br>
+                The argument <span class="term">text</span> is the text object itself.
+                <br><br>
+                If this value isn't set and the function <span class="term">OnTextComplete()</span> exists in the Encounter
+                script, it will call it with the text object as its argument.
+            </p>
+            <p>
                 <br><span class="function">Text.SkipLine()</span>
                 This function skips to the end of the text object's current text, as if using the text command <span class="term">[instant]</span>.<br>
                 If <span class="term">playerskipdocommand</span> is true, this function will behave the same as a player skip.

--- a/Documentation CYF 1.0/pages/cyf-text.html
+++ b/Documentation CYF 1.0/pages/cyf-text.html
@@ -162,6 +162,16 @@ it's w3c valid, at least
                 The 4th value is the alpha (transparency) value of the text.
             </p>
             <p>
+                <br><span class="new function"><span class="luatable"><span class="number"></span>, <span class="number"></span>,
+                <span class="number"></span> = 1 </span> Text.bubbleColor</span>
+                Get or set the color of the text object's bubble graphics, as a table of 3 values from 0 to 1.
+            </p>
+            <p>
+                <br><span class="new function"><span class="luatable"><span class="number"></span>, <span class="number"></span>,
+                <span class="number"></span> = 255 </span> Text.bubbleColor32</span>
+                Get or set the color of the text object's bubble graphics, as a table of 3 integer values from 0 to 255.
+            </p>
+            <p>
                 <br><span class="function">Text.ResetColor(<span class="boolean"></span> resetAlpha = false)</span>
                 Resets any previous set of the variable <span class="term">Text.color</span> or <span class="term">Text.color32</span>,
                 resetting the text's default color to the font's default color.<br>


### PR DESCRIPTION
1. Add Text.bubbleColor/bubbleColor32.

2. Add Text.OnTextComplete.

3. Allow [lettereffect] for immediate text. Useful when you want an act command have a different effect from the other commands. Now this command also runs even if you skip text, but I don't see a reason why it shouldn't.

4. The text engine ties its letter timer to the game's speed setting, but the rest of the typewriter logic assumes a fixed frame rate, so changing timeScale (or even a single uneven frame) sometimes makes the timer and the character counter disagree, the dialogue line never registers as "finished," and it freezes without advancing. Fix by changing letterTimer += Time.deltaTime to unscaledDeltaTime.
The fix decouples the timer from the speed setting so it ticks one steady step per frame, keeping everything in sync regardless of speed or frame timing.
In short: If you set Time.timeScale to a big number (10), a dialogue will freeze at some point (but sometimes with a normal timeScale too).